### PR TITLE
STORE-96, STORE-103,STORE-112,STORE-113,STORE-127

### DIFF
--- a/modules/apps/publisher/config/storage.json
+++ b/modules/apps/publisher/config/storage.json
@@ -2,7 +2,7 @@
     "driverPath":"/drivers/",
     "driverUsed":"default",
     "dataSource":"JAGH2",
-    "storageUrlPattern":"http://{ip}:{http}/{context}/storage/{type}/{id}/{uuid}",
+    "storageUrlPattern":"https://{ip}:{https}/{context}/storage/{type}/{id}/{uuid}",
     "storeFields":["images_banner","images_thumbnail"],
     "context":"publisher"
 }

--- a/modules/apps/publisher/modules/data/injectors/asset.display.injector.js
+++ b/modules/apps/publisher/modules/data/injectors/asset.display.injector.js
@@ -130,6 +130,7 @@ var injector = function () {
         storageUrlPattern=storageUrlPattern.replace('{ip}',ip);
 
         storageUrlPattern=storageUrlPattern.replace('{http}',http);
+        storageUrlPattern=storageUrlPattern.replace('{https}',https);
 
         storageUrlPattern=storageUrlPattern.replace('{context}',context);
         storageUrlPattern=storageUrlPattern.replace('{uuid}',uuid);

--- a/modules/apps/store/modules/data/injectors/asset.display.injector.js
+++ b/modules/apps/store/modules/data/injectors/asset.display.injector.js
@@ -130,6 +130,7 @@ var injector = function () {
         storageUrlPattern=storageUrlPattern.replace('{ip}',ip);
 
         storageUrlPattern=storageUrlPattern.replace('{http}',http);
+        storageUrlPattern=storageUrlPattern.replace('{https}',https);
 
         storageUrlPattern=storageUrlPattern.replace('{context}',context);
         storageUrlPattern=storageUrlPattern.replace('{uuid}',uuid);


### PR DESCRIPTION
The issue stemmed from the creation of multiple sessions due to Tomcat sharing session data between http and https requests.

The solution involved serving all images through https in the case of the publisher.

The ability to serve content using https was added to the Store as well.

To change the protocol used adjust the url provided in config/storage.json
