### PR TITLE
STORE-235 & STORE 141

### DIFF
--- a/modules/apps/publisher/modules/security/storage.security.provider.js
+++ b/modules/apps/publisher/modules/security/storage.security.provider.js
@@ -82,7 +82,7 @@ var securityModule = function () {
         var asset=artifactManager.get(assetId);
 
         //Obtain the signed in user
-        var user=session.get(LOGGED_IN_USER);
+        var userInstance=require('/modules/user.js').current(session);
 
         var roles=[];
 
@@ -93,7 +93,6 @@ var securityModule = function () {
         }
         else{
             //Obtain the roles
-            var userInstance=this.um.getUser(user);
             roles=userInstance.getRoles();
         }
 

--- a/modules/apps/publisher/themes/default/js/logic/create.asset.js
+++ b/modules/apps/publisher/themes/default/js/logic/create.asset.js
@@ -97,8 +97,14 @@ $(function () {
      @returns: An array containing the tags selected by the user
      */
     function obtainTags() {
-        var tags = $(TAG_CONTAINER).tokenInput('get');
+
         var tagArray = [];
+
+        if($(TAG_CONTAINER)){
+            return tagArray;
+        }
+
+        var tags = $(TAG_CONTAINER).tokenInput('get');
 
         for (var index in tags) {
             tagArray.push(tags[index].name);

--- a/modules/apps/store/modules/security/storage.security.provider.js
+++ b/modules/apps/store/modules/security/storage.security.provider.js
@@ -21,8 +21,12 @@ var securityModule = function () {
     var ROLE_ADMIN='admin';
     var ROLE_ANON='anon';
 
+    var CONFIG_PATH='/config/ext';
 
-    function SecurityProvider(context) {
+
+    function SecurityProvider() {
+        var context={};
+        context['path']=CONFIG_PATH;
         this.storageBlocks = {};
         this.context = context;
 

--- a/modules/apps/store/routers/storage_router.jag
+++ b/modules/apps/store/routers/storage_router.jag
@@ -18,9 +18,10 @@ var ERROR_AUTH_REQ="You must be logged in to access this resource";
 var log=new Log('storage.router');
 
 var storageModule = require('/modules/data/storage.js').storageModule();
-var securityProviderModule=require('/modules/security/storage.security.provider.js').securityModule();
 
-var storageSecurityProvider=securityProviderModule.cached();
+var store=require('/modules/store.js').storeManagers(request,session);
+
+var storageSecurityProvider=store.storageSecurityProvider;
 
 var storageManager = new storageModule.StorageManager({
     context: 'storage',


### PR DESCRIPTION
Part 2 and 3 of the fixes to allow images to be visible by tenants.

STORE-235:
The issue was caused by a problem with the client script not initializing the tokenInput plug-in when the request for tags fail. (This has been added as a separate issue)

The issue was fixed by first checking if a tokenInput element is present before attempting to retrieve the tags selected by the user.

STORE-141
The storage security provider was cached in the application context and therefore once a tenant logs in it continues to use the registry and user manager from the previous user.

This was rectified by moving the Store storage security provider to the session and adding it to the managers object of the store script. This change also moved the caching of the provided tenant from application context to the session.

Store:
-Anon users can view images 
-Logged in tenants can view images of published assets
