### PR TITLE
Fix STORE-241

### DIFF
--- a/modules/apps/publisher/apis/v1/lifecycle_api_router.jag
+++ b/modules/apps/publisher/apis/v1/lifecycle_api_router.jag
@@ -304,7 +304,7 @@ routeManager.register('GET','publisher','/publisher/api/lifecycle/information/hi
 
        log.debug('history retrieved from '+historyPath);
 
-       var systemRegistry=server.systemRegistry();
+       var systemRegistry=rxtManager.registry;//server.systemRegistry();
 
        //var actions=artifactManager.availableActions(artifact);
 


### PR DESCRIPTION
Fixes the lifecycle history not been rendered for tenants.

The fix involved changing the registry used to obtain the history information from system to the currently logged in user.

Changes:
routers/lifecycle_api_router.jag
