### PR TITLE
Fix for STORE-327, STORE-328 and STORE-231

### DIFF
--- a/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryTravellingPermissionLifeCycle.java
+++ b/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryTravellingPermissionLifeCycle.java
@@ -510,7 +510,7 @@ public class JaggeryTravellingPermissionLifeCycle extends Aspect {
             throw new RegistryException(e.getMessage());
         }
         finally{
-           // JaggeryThreadLocalMediator.unset();
+            JaggeryThreadLocalMediator.unset();
         }
     }
 


### PR DESCRIPTION
The issue involved gadgets randomly disappearing from the store after seemingly random set of actions.

The cause of the issue was traced to a ThreadLocal variable which was not been unset properly in the JaggerySCXMLExecutor.

The fix involved doing an unset in a final clause.

The issue was reproduced by;
1. Setting the Tomcat thread count to max: 25 and min 5
2. Logging in as a user
3. Creating an asset
4. Promoting to the In-Review state
5. Clicking the Publish action approximately 25 times (25+)
6. Logging in as the admin
7. Promoting to the Published state
8. Logging in as the user who created to the store
9. Bookmarking the asset
10. This would cause the store to crash
