### PR TITLE
Fix for STORE-352

### DIFF
--- a/modules/apps/publisher/config/lifecycles/MobileAppLifeCycle.xml
+++ b/modules/apps/publisher/config/lifecycles/MobileAppLifeCycle.xml
@@ -94,7 +94,7 @@
                                 <parameter name="PERMISSION:authorize" value="authorize"/>
 
                                 <parameter name="STATE_RULE1:Published"
-                                           value="Internal/private_{asset_author}:-add,+delete,-authorize"/>
+                                           value="Internal/private_{asset_author}:+add,+delete,+authorize"/>
                                 <parameter name="STATE_RULE2:Published"
                                            value="Internal/reviewer:-add,-delete,-authorize"/>
                                 <parameter name="STATE_RULE3:Published"
@@ -138,7 +138,7 @@
                                 <parameter name="PERMISSION:authorize" value="authorize"/>
 
                                 <parameter name="STATE_RULE1:Unpublished"
-                                           value="Internal/private_{asset_author}:-add,-delete,-authorize"/>
+                                           value="Internal/private_{asset_author}:+add,+delete,+authorize"/>
                                 <parameter name="STATE_RULE2:Unpublished"
                                            value="Internal/reviewer:-add,-delete,-authorize"/>
                                 <parameter name="STATE_RULE3:Unpublished"
@@ -154,7 +154,7 @@
                                 <parameter name="PERMISSION:authorize" value="authorize"/>
 
                                 <parameter name="STATE_RULE1:Deprecated"
-                                           value="Internal/private_{asset_author}:-add,-delete,-authorize"/>
+                                           value="Internal/private_{asset_author}:+add,+delete,+authorize"/>
                                 <parameter name="STATE_RULE2:Deprecated"
                                            value="Internal/reviewer:-add,-delete,-authorize"/>
                                 <parameter name="STATE_RULE3:Deprecated"


### PR DESCRIPTION
Fixed by changing the permissions for the Published state transitions.

The private_user was given the +add,+delete+authorize access when switching to the Unpublished or Deprecated states.
