### PR TITLE
fixed issue of publisher crashing when adding fields with commas

### DIFF
--- a/modules/apps/publisher/modules/ext/scripts/asset.exporter.js
+++ b/modules/apps/publisher/modules/ext/scripts/asset.exporter.js
@@ -39,7 +39,7 @@ var module = function () {
                     tableName = table.name;
                     fieldName = field.name;
                     //log.info('Creating attributes ' + tableName + '_' + fieldName + '' + field.value.toString().split(','));
-                    attributes[tableName + '_' + fieldName] = getValue(field);//field.value.toString().split(',');
+                    attributes[tableName + '_' + fieldName] = ''+getValue(field);//field.value.toString().split(',');
                     //log.info('Value assigned');
                 }
             }


### PR DESCRIPTION
Issue was at /publisher/modules/ext/scripts/asset.exporter.js

Issue was when attributes are assigned to JSON object here, fields with commas are assigned as JSON Arrays.
