### PR TITLE
Anonymous tenant view test cases

### DIFF
--- a/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreAnonSuperTenantHomePageTestCase.java
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreAnonSuperTenantHomePageTestCase.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+package org.wso2.es.ui.integration.test.store;
+
+import org.wso2.es.ui.integration.util.ESUtil;
+
+/**
+ * Tests the homepage of the Store when it is accessed by
+ * an anonymous user with the tenant url (t/carbon.super)
+ */
+public class ESStoreAnonSuperTenantHomePageTestCase extends ESStoreAnonHomePageTestCase {
+    @Override
+    public  String resolveStoreUrl(){
+       String tenantDomain = "carbon.super";//TODO: Obtain this from the automation context
+       return baseUrl+STORE_URL+ ESUtil.getTenantQualifiedUrl(tenantDomain);
+    }
+}

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreAnonTenantHomePageTestCase.java
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreAnonTenantHomePageTestCase.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.es.ui.integration.test.store;
+
+import org.openqa.selenium.By;
+import org.testng.annotations.Test;
+import org.wso2.es.ui.integration.util.ESUtil;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests the homepage of a tenant when it is accessed
+ * by an anonymous user
+ * 1. Checks if the homepage (top-assets) is rendered
+ * 2. Checks if the gadget and site links are present
+ * 3. Checks if the gadget and site listing pages are rendered
+ */
+public class ESStoreAnonTenantHomePageTestCase extends ESStoreAnonHomePageTestCase {
+    @Override
+    public String resolveStoreUrl() {
+        String tenantDomain = "wso2.com";//TODO:Obtain this from the anon context
+        return baseUrl + STORE_URL + ESUtil.getTenantQualifiedUrl(tenantDomain);
+    }
+
+    @Override
+    @Test(groups = "wso2.es.store", description = "Test if the homepage loads when using /t/domain as anon user")
+    public void testAnonHomePage() throws Exception {
+        //test appearance
+        driver.get(resolveStoreUrl());
+        assertTrue(isElementPresent(driver, By.cssSelector("a.brand")), "Home Page error: Logo missing");
+        assertEquals("Gadget", driver.findElement(By.xpath("//div[@id='container-search']/div/div/div/div/a[1]/li"))
+                .getText(), "Home Page error: Gadget menu missing");
+        assertEquals("Site", driver.findElement(By.xpath("//div[@id='container-search']/div/div/div/div/a[2]/li"))
+                .getText(), "Home Page error: Site menu missing");
+    }
+
+    @Test(groups = "wso2.es.store", description = "Test if the asset listing page loads when using /t/domain as anon " +
+            "user")
+    public void testAnonAssetListingPage() throws Exception {
+        driver.get(resolveStoreUrl()+"/asts/gadget/list");
+        assertTrue(isElementPresent(driver, By.cssSelector("a.brand")), "Home Page error: Logo missing");
+    }
+
+    @Override
+    @Test(groups = "wso2.es.store", description = "Test if the navigation menu works")
+    public void testAnonNavigationTop() throws Exception {
+    }
+
+    @Override
+    @Test(groups = "wso2.es.store", description = "Test if the navigation links work")
+    public void testAnonNavigationLinks() throws Exception {
+    }
+}

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreTUAccessInvalidTenantTestCase.java
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreTUAccessInvalidTenantTestCase.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.es.ui.integration.test.store;
+
+import org.openqa.selenium.By;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.extensions.selenium.BrowserManager;
+import org.wso2.es.ui.integration.util.BaseUITestCase;
+import org.wso2.es.ui.integration.util.ESUtil;
+import org.wso2.es.ui.integration.util.ESWebDriver;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Accesses pages using a tenant that does not exist
+ * 1. Checks if the homepage (top-assets) returns a 404 error
+ * 2. Checks if the asset listing page returns a 404 error
+ * 3. Checks if an asset details page returns a 404 error
+ */
+public class ESStoreTUAccessInvalidTenantTestCase extends BaseUITestCase {
+
+
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() throws Exception {
+        super.init();
+        driver = new ESWebDriver(BrowserManager.getWebDriver());
+        baseUrl = getWebAppURL();
+    }
+
+    /**
+     * The method returns the store url of the homepage
+     * @return A string url to the store homepage
+     */
+    public String resolveStoreUrl() {
+        String tenantDomain = ESUtil.getTenantQualifiedUrl(NONE_EXIST_TENANT_DOMAIN);
+        return baseUrl + STORE_URL +tenantDomain;
+    }
+
+    @Test(groups = "wso2.es.store", description = "Test if accessing the homepage of foo.com returns a 404 error")
+    public void testAnonHomePage() throws Exception {
+        driver.get(resolveStoreUrl());
+        checkErrorPresent();
+    }
+
+
+    @Test(groups = "wso2.es.store", description = "Test if accessing the asset listing page of foo.com returns a 404 error")
+    public void testAssetListingPage() throws Exception {
+        driver.get(resolveStoreUrl() + "/asts/gadget/list");
+        checkErrorPresent();
+    }
+
+    private void checkErrorPresent() {
+        assertEquals(ERROR_404, driver.findElement(By.xpath("//h1[contains(text()," +
+                "'Error 404')]")).getText(), "Error 404 error code is missing");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+        driver.quit();
+    }
+}

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreTenantUserTUHomePageTestCase.java
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/java/org/wso2/es/ui/integration/test/store/ESStoreTenantUserTUHomePageTestCase.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.es.ui.integration.test.store;
+
+import org.openqa.selenium.By;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
+import org.wso2.carbon.automation.extensions.selenium.BrowserManager;
+import org.wso2.es.ui.integration.util.BaseUITestCase;
+import org.wso2.es.ui.integration.util.ESUtil;
+import org.wso2.es.ui.integration.util.ESWebDriver;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * The test first logs in the tenant admin for wso2.com and
+ * then checks the behaviour of the Store Home Page
+ * 1. Checks if the homepage loads (top-assets page)
+ * 2. Checks if the gadget and site links are present
+ * 3. Checks if the gadget listing page is rendered
+ * 4. Checks if the site listing page is rendered
+ */
+public class ESStoreTenantUserTUHomePageTestCase extends BaseUITestCase {
+    protected static final int MAX_POLL_COUNT = 30;
+    @BeforeClass(alwaysRun = true)
+    public void setUp() throws Exception {
+        super.init();
+        driver = new ESWebDriver(BrowserManager.getWebDriver());
+        baseUrl = getWebAppURL();
+        login();
+    }
+
+    public void login() throws Exception {
+        super.init(TestUserMode.TENANT_ADMIN);
+        currentUserName = userInfo.getUserName();
+        currentUserPwd = userInfo.getPassword();
+        buildTenantDetails(TestUserMode.TENANT_ADMIN);
+        ESUtil.login(driver, baseUrl, STORE_APP, currentUserName, currentUserPwd);
+    }
+
+    public String resolveStoreUrl()  {
+        String tenantDomain = tenantDetails.getDomain();
+        return baseUrl + STORE_URL + ESUtil.getTenantQualifiedUrl(tenantDomain);
+    }
+
+    @Test(groups = "wso2.es.store", description = "Test accessing homepage with a logged in tenant user using " +
+            "the tenant url(t/wso2.com)")
+    public void testLoggedInHomePage() throws Exception {
+        driver.get(resolveStoreUrl());
+        assertTrue(isElementPresent(driver, By.cssSelector("a.brand")), "Home Page error: Logo missing");
+        assertEquals("Gadget", driver.findElement(By.xpath("//div[@id='container-search']/div/div/div/div/a[1]/li"))
+                .getText(), "Home Page error: Gadget menu missing");
+        assertEquals("Site", driver.findElement(By.xpath("//div[@id='container-search']/div/div/div/div/a[2]/li"))
+                .getText(), "Home Page error: Site menu missing");
+    }
+
+    @Test(groups="wso2.es.store" , description = "Test accessing asset listing page with a logged in tenant" +
+            "user using the tenant url(t/wso2.com)")
+    public void testAssetListingPage() throws Exception{
+        driver.get(resolveStoreUrl()+"/asts/gadget/list");
+        assertTrue(isElementPresent(driver, By.cssSelector("a.brand")), "Home Page error: Logo missing");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+        driver.quit();
+    }
+}

--- a/modules/integration/tests-ui-integration/ui-test-utils/src/main/java/org/wso2/es/ui/integration/util/BaseUITestCase.java
+++ b/modules/integration/tests-ui-integration/ui-test-utils/src/main/java/org/wso2/es/ui/integration/util/BaseUITestCase.java
@@ -21,6 +21,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.engine.context.beans.Tenant;
 import org.wso2.es.integration.common.clients.ResourceAdminServiceClient;
 import org.wso2.es.integration.common.utils.ESIntegrationUITest;
 
@@ -52,6 +55,8 @@ public abstract class BaseUITestCase extends ESIntegrationUITest {
     protected static final String STORE_GADGET_LIST_PAGE = "/store/asts/gadget/list";
     protected static final String STORE_TOP_ASSETS_PAGE = "/store/pages/top-assets";
     protected static final String GADGET_REGISTRY_BASE_PATH = "/_system/governance/gadgets/";
+    protected static final String NONE_EXIST_TENANT_DOMAIN = "foo.com";
+    protected static final String ERROR_404 = "Error 404";
 
     protected static final int MAX_DRIVER_WAIT_TIME_SEC = 30;
 
@@ -60,6 +65,7 @@ public abstract class BaseUITestCase extends ESIntegrationUITest {
     protected String adminUserName;
     protected String adminUserPwd;
     protected String providerName;
+    protected Tenant tenantDetails;
 
     protected String resourcePath;
     protected String smtpPropertyLocation;
@@ -76,7 +82,7 @@ public abstract class BaseUITestCase extends ESIntegrationUITest {
             driver.findElement(by);
             return true;
         } catch (NoSuchElementException e) {
-            if(LOG.isDebugEnabled()){
+            if (LOG.isDebugEnabled()) {
                 LOG.debug("Requested element is not present", e);
             }
             return false;
@@ -93,7 +99,7 @@ public abstract class BaseUITestCase extends ESIntegrationUITest {
             driver.switchTo().alert();
             return true;
         } catch (NoAlertPresentException e) {
-            if(LOG.isDebugEnabled()) {
+            if (LOG.isDebugEnabled()) {
                 LOG.debug("No alert found", e);
             }
             return false;
@@ -114,5 +120,10 @@ public abstract class BaseUITestCase extends ESIntegrationUITest {
             alert.dismiss();
         }
         return alertText;
+    }
+
+    protected void buildTenantDetails(TestUserMode userMode) throws Exception {
+        AutomationContext automationContext = new AutomationContext(PRODUCT_GROUP_NAME, userMode);
+        tenantDetails = automationContext.getContextTenant();
     }
 }

--- a/modules/integration/tests-ui-integration/ui-test-utils/src/main/java/org/wso2/es/ui/integration/util/ESUtil.java
+++ b/modules/integration/tests-ui-integration/ui-test-utils/src/main/java/org/wso2/es/ui/integration/util/ESUtil.java
@@ -45,6 +45,7 @@ public class ESUtil extends ESIntegrationUITest {
     private static final String IMAPS = "imaps";
     public static final String SMTP_GMAIL_COM = "smtp.gmail.com";
     public static final String INBOX = "inbox";
+    private static final String TENANT_TOKEN = "/t/";
 
     /**
      * To login to store or publisher
@@ -101,6 +102,9 @@ public class ESUtil extends ESIntegrationUITest {
         driver.findElement(By.linkText("Sign out")).click();
     }
 
+    public static String getTenantQualifiedUrl(String domain){
+        return TENANT_TOKEN+domain;
+    }
     /**
      * To login to admin console
      *
@@ -249,6 +253,7 @@ public class ESUtil extends ESIntegrationUITest {
         }
         return false;
     }
+
 
     private static String getErrorMessage(String emailAddress) {
         return "Retrieving mails for: " + emailAddress + "failed";


### PR DESCRIPTION
This PR adds a set of UI tests to verify anonymous tenant views of the Store

1. Test anonymous and logged in views of the carbon.super store 
2. Test anonymous and logged in views of tenant store
3. Test anonymous view of a tenant that does not exist (foo.com)