### PR TITLE
Carbon 4.4.0 Upgrade for App Manager 1.1.0

### DIFF
--- a/modules/components/jaggery-scxml-executors/pom.xml
+++ b/modules/components/jaggery-scxml-executors/pom.xml
@@ -4,14 +4,13 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
   
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jaggery-scxml-executors</artifactId>
   <packaging>bundle</packaging>
-  <version>1.1.1</version>
   <name>jaggery-scxml-executors</name>
   <url>http://maven.apache.org</url>
   <properties>
@@ -66,7 +65,7 @@
               <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
 	      <Service-Component>OSGI-INF/serviceComponents.xml</Service-Component>
               <Bundle-Name>${pom.artifactId}</Bundle-Name>
-              <Bundle-Version>1.1.1</Bundle-Version>
+              <Bundle-Version>${carbon.store.bundle.version}</Bundle-Version>
               <Private-Package>org.wso2.jaggery.scxml</Private-Package>
               <Bundle-Activator>org.wso2.jaggery.scxml.Activator</Bundle-Activator>
               <Import-Package>

--- a/modules/components/jaggery-scxml-executors/pom.xml
+++ b/modules/components/jaggery-scxml-executors/pom.xml
@@ -4,14 +4,14 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
   
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jaggery-scxml-executors</artifactId>
   <packaging>bundle</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>jaggery-scxml-executors</name>
   <url>http://maven.apache.org</url>
   <properties>
@@ -66,7 +66,7 @@
               <Bundle-SymbolicName>${pom.groupId}.${pom.artifactId}</Bundle-SymbolicName>
 	      <Service-Component>OSGI-INF/serviceComponents.xml</Service-Component>
               <Bundle-Name>${pom.artifactId}</Bundle-Name>
-              <Bundle-Version>1.1.0</Bundle-Version>
+              <Bundle-Version>1.1.1</Bundle-Version>
               <Private-Package>org.wso2.jaggery.scxml</Private-Package>
               <Bundle-Activator>org.wso2.jaggery.scxml.Activator</Bundle-Activator>
               <Import-Package>
@@ -101,9 +101,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.wso2.carbon</groupId>
+      <groupId>org.wso2.carbon.governance</groupId>
       <artifactId>org.wso2.carbon.governance.registry.extensions</artifactId>
-      <version>4.1.3</version>
+      <version>${carbon.governance.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryDefaultLifeCycle.java
+++ b/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryDefaultLifeCycle.java
@@ -213,11 +213,13 @@ public class JaggeryDefaultLifeCycle extends Aspect {
 
 //            Creating the checklist
 //            this is the first time the life cycle is associated with a resource.
+            String aspectName = scxml.getInitial();
             String initialState = scxml.getInitial();
-            addCheckItems(resource, checkListItems.get(initialState), initialState);
-            addTransitionApprovalItems(resource, transitionApproval.get(initialState), initialState);
-            addScripts(initialState, resource,scriptElements.get(initialState));
-            addTransitionUI(resource,transitionUIs.get(initialState));
+            addCheckItems(resource, checkListItems.get(initialState), initialState, aspectName);
+            addTransitionApprovalItems(resource, transitionApproval.get(initialState), initialState,
+                    aspectName);
+            addScripts(initialState, resource,scriptElements.get(initialState), aspectName);
+            addTransitionUI(resource,transitionUIs.get(initialState), aspectName);
 
         } catch (Exception e) {
             String message = "Resource does not contain a valid XML configuration: " + e.toString();
@@ -454,14 +456,16 @@ public class JaggeryDefaultLifeCycle extends Aspect {
 
         if (!currentState.equals(nextState)) {
             State state = (State) scxml.getChildren().get(nextState);
+            String aspectName = scxml.getInitial();
             resource.setProperty(stateProperty, state.getId().replace(".", " "));
 
-            clearCheckItems(resource);
-            clearTransitionApprovals(resource);
-            addCheckItems(resource, checkListItems.get(state.getId()), state.getId());
-            addTransitionApprovalItems(resource, transitionApproval.get(state.getId()), state.getId());
-            addScripts(state.getId(), resource,scriptElements.get(state.getId()));
-            addTransitionUI(resource, transitionUIs.get(state.getId()));
+            clearCheckItems(resource, aspectName);
+            clearTransitionApprovals(resource, aspectName);
+            addCheckItems(resource, checkListItems.get(state.getId()), state.getId(), aspectName);
+            addTransitionApprovalItems(resource, transitionApproval.get(state.getId()),
+                    state.getId(), aspectName);
+            addScripts(state.getId(), resource, scriptElements.get(state.getId()), aspectName);
+            addTransitionUI(resource, transitionUIs.get(state.getId()), aspectName);
 
             //            For auditing purposes
             statCollection.setTargetState(nextState);

--- a/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryTravellingPermissionLifeCycle.java
+++ b/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/aspects/JaggeryTravellingPermissionLifeCycle.java
@@ -255,11 +255,12 @@ public class JaggeryTravellingPermissionLifeCycle extends Aspect {
 
 //            Creating the checklist
 //            this is the first time the life cycle is associated with a resource.
+            String aspectName = scxml.getInitial();
             String initialState = scxml.getInitial();
-            addCheckItems(resource, checkListItems.get(initialState), initialState);
-            addTransitionApprovalItems(resource, transitionApproval.get(initialState), initialState);
-            addScripts(initialState, resource,scriptElements.get(initialState));
-            addTransitionUI(resource,transitionUIs.get(initialState));
+            addCheckItems(resource, checkListItems.get(initialState), initialState, aspectName);
+            addTransitionApprovalItems(resource, transitionApproval.get(initialState), initialState, aspectName);
+            addScripts(initialState, resource,scriptElements.get(initialState), aspectName);
+            addTransitionUI(resource,transitionUIs.get(initialState), aspectName);
 
         } catch (Exception e) {
             String message = "Resource does not contain a valid XML configuration: " + e.toString();
@@ -483,15 +484,16 @@ public class JaggeryTravellingPermissionLifeCycle extends Aspect {
         newResourcePath = requestContext.getResourcePath().getPath();
 
         if (!currentState.equals(nextState)) {
+            String aspectName = scxml.getInitial();
             State state = (State) scxml.getChildren().get(nextState);
             resource.setProperty(stateProperty, state.getId().replace(".", " "));
 
-            clearCheckItems(resource);
-            clearTransitionApprovals(resource);
-            addCheckItems(resource, checkListItems.get(state.getId()), state.getId());
-            addTransitionApprovalItems(resource, transitionApproval.get(state.getId()), state.getId());
-            addScripts(state.getId(), resource,scriptElements.get(state.getId()));
-            addTransitionUI(resource, transitionUIs.get(state.getId()));
+            clearCheckItems(resource, aspectName);
+            clearTransitionApprovals(resource, aspectName);
+            addCheckItems(resource, checkListItems.get(state.getId()), state.getId(), aspectName);
+            addTransitionApprovalItems(resource, transitionApproval.get(state.getId()), state.getId(), aspectName);
+            addScripts(state.getId(), resource,scriptElements.get(state.getId()), aspectName);
+            addTransitionUI(resource, transitionUIs.get(state.getId()), aspectName);
 
             //            For auditing purposes
             statCollection.setTargetState(nextState);
@@ -499,7 +501,7 @@ public class JaggeryTravellingPermissionLifeCycle extends Aspect {
         if (!preserveOldResource) {
             requestContext.getRegistry().delete(resourcePath);
         }
-        requestContext.getRegistry().put(newResourcePath, resource);
+//        requestContext.getRegistry().put(newResourcePath, resource);
 
         //        adding the logs to the registry
         if (isAuditEnabled) {

--- a/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/generic/GenericExecutor.java
+++ b/modules/components/jaggery-scxml-executors/src/main/java/org/wso2/jaggery/scxml/generic/GenericExecutor.java
@@ -79,11 +79,11 @@ public class GenericExecutor implements Execution
         //Set the asset author key
 	//Workaround for https://wso2.org/jira/browse/REGISTRY-2214
         boolean isEmailEnabled = Boolean.parseBoolean(CarbonUtils.getServerConfiguration().getFirstProperty("EnableEmailUserName"));
-        String provider = requestContext.getResource().getProperty("overview_provider");
-        if (provider != null && !isEmailEnabled && provider.contains("-AT-")) {
-            provider = provider.substring(0, provider.indexOf("-AT-"));
-
-        }
+        String provider = requestContext.getResource().getAuthorUserName();
+//        if (provider != null && !isEmailEnabled && provider.contains("-AT-")) {
+//            provider = provider.substring(0, provider.indexOf("-AT-"));
+//
+//        }
 	//dynamicValueInjector.setDynamicValue(DynamicValueInjector.ASSET_AUTHOR_KEY,requestContext.getResource().getAuthorUserName());
         dynamicValueInjector.setDynamicValue(DynamicValueInjector.ASSET_AUTHOR_KEY,provider);
 

--- a/modules/components/social/org.wso2.carbon.social.core/pom.xml
+++ b/modules/components/social/org.wso2.carbon.social.core/pom.xml
@@ -4,13 +4,13 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.core</artifactId>
     <packaging>bundle</packaging>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>WSO2 Carbon - Social - Core</name>
     <build>
        <plugins>
@@ -37,7 +37,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Axis2Module>${project.artifactId}-${project.version}</Axis2Module>
                         <Export-Package>
-                            org.wso2.carbon.social.core.*
+                            org.wso2.carbon.social.core.*;version="${carbon.social.pkg.version}"
                         </Export-Package>
                         <Private-Package>
                             org.wso2.carbon.social.core.internal

--- a/modules/components/social/org.wso2.carbon.social.core/pom.xml
+++ b/modules/components/social/org.wso2.carbon.social.core/pom.xml
@@ -73,17 +73,17 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.ndatasource.rdbms</artifactId>
-	    <version>4.2.0</version>
+	    <version>${carbon.kernal.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.ndatasource.core</artifactId>
-	    <version>4.2.0</version>
+	    <version>${carbon.kernal.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.1</version>
+            <version>${google.gson.version}</version>
         </dependency>
         <dependency>
             <groupId>rhino.wso2</groupId>

--- a/modules/components/social/org.wso2.carbon.social.db.adapter/pom.xml
+++ b/modules/components/social/org.wso2.carbon.social.db.adapter/pom.xml
@@ -2,12 +2,12 @@
       <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.wso2.carbon.social.db.adapter</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>WSO2 Carbon - Social - Default DB Adapter</name>
   <dependencies>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.social.core</artifactId>
-	    <version>1.2.0</version>
+	    <version>${carbon.social.version}</version>
         </dependency>
   </dependencies>
   <build>
@@ -48,7 +48,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Axis2Module>${project.artifactId}-${project.version}</Axis2Module>
                         <Export-Package>
-                            org.wso2.carbon.social.db.adapter.*
+                            org.wso2.carbon.social.db.adapter.*;version="${carbon.social.pkg.version}"
                         </Export-Package>
                         <Private-Package>
                             org.wso2.carbon.social.db.adapter.internal

--- a/modules/components/social/org.wso2.carbon.social.sql/pom.xml
+++ b/modules/components/social/org.wso2.carbon.social.sql/pom.xml
@@ -4,19 +4,19 @@
     <parent>
         <groupId>org.wso2.carbon</groupId>
         <artifactId>social</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.sql</artifactId>
 	<packaging>bundle</packaging>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <name>WSO2 Carbon - Social - SQL Based Implementation</name>
     <dependencies>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.social.core</artifactId>
-	    <version>1.2.0</version>
+	    <version>${carbon.social.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -44,7 +44,7 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Axis2Module>${project.artifactId}-${project.version}</Axis2Module>
                         <Export-Package>
-                            org.wso2.carbon.social.sql.*
+                            org.wso2.carbon.social.sql.*;version="${carbon.social.pkg.version}"
                         </Export-Package>
                         <Import-Package>
                             javax.servlet;version="[2.6.0, 3.0.0)",

--- a/modules/components/social/pom.xml
+++ b/modules/components/social/pom.xml
@@ -5,13 +5,13 @@
    <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.wso2.carbon</groupId>
     <artifactId>social</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Social Aggregator Module</name>

--- a/modules/components/social/pom.xml
+++ b/modules/components/social/pom.xml
@@ -5,7 +5,7 @@
    <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
@@ -21,8 +21,5 @@
         <module>org.wso2.carbon.social.sql</module>
 		<module>org.wso2.carbon.social.db.adapter</module>
     </modules>
-    
-    <properties>
-        <carbon.platform.version>4.2.0</carbon.platform.version>
-    </properties>
+
 </project>

--- a/modules/components/sso-common/pom.xml
+++ b/modules/components/sso-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/components/sso-common/pom.xml
+++ b/modules/components/sso-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/components/store-admin/pom.xml
+++ b/modules/components/store-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/components/store-admin/pom.xml
+++ b/modules/components/store-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/org.wso2.store.feature/pom.xml
+++ b/modules/features/org.wso2.store.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-features</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.wso2.store</groupId>
             <artifactId>org.wso2.store.sso.common</artifactId>
-            <version>${ues.version}</version>
+            <version>${carbon.store.bundle.version}</version>
         </dependency>
        <!-- <dependency>
             <groupId>org.wso2.carbon</groupId>
@@ -82,8 +82,9 @@
                             <bundles>
                                 <bundleDef>slf4j.wso2:slf4j:1.5.10.wso2v1</bundleDef>
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.hostobjects.sso</bundleDef>-->
-                                <bundleDef>org.wso2.store:org.wso2.store.sso.common:${carbon.store.bundle.version}</bundleDef>
-                                <bundleDef>org.wso2.store:org.wso2.store.admin.styles</bundleDef>
+                                <bundleDef>
+                                    org.wso2.store:org.wso2.store.sso.common:${carbon.store.bundle.version}</bundleDef>
+                                <bundleDef>org.wso2.store:org.wso2.store.admin.styles:${carbon.store.bundle.version}</bundleDef>
                                 <!--<bundleDef>org.wso2.store:org.wso2.carbon.social:1.0.0</bundleDef>-->
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.databridge.datasink.cassandra</bundleDef>-->
                                 <bundleDef>org.wso2.store:jaggery-scxml-executors:${carbon.store.bundle.version}</bundleDef>

--- a/modules/features/org.wso2.store.feature/pom.xml
+++ b/modules/features/org.wso2.store.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-features</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -82,11 +82,11 @@
                             <bundles>
                                 <bundleDef>slf4j.wso2:slf4j:1.5.10.wso2v1</bundleDef>
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.hostobjects.sso</bundleDef>-->
-                                <bundleDef>org.wso2.store:org.wso2.store.sso.common:1.1.0</bundleDef>
+                                <bundleDef>org.wso2.store:org.wso2.store.sso.common:${carbon.store.bundle.version}</bundleDef>
                                 <bundleDef>org.wso2.store:org.wso2.store.admin.styles</bundleDef>
                                 <!--<bundleDef>org.wso2.store:org.wso2.carbon.social:1.0.0</bundleDef>-->
                                 <!--<bundleDef>org.wso2.carbon:org.wso2.carbon.databridge.datasink.cassandra</bundleDef>-->
-                                <bundleDef>org.wso2.store:jaggery-scxml-executors:1.1.0</bundleDef>
+                                <bundleDef>org.wso2.store:jaggery-scxml-executors:${carbon.store.bundle.version}</bundleDef>
                             </bundles>
                             <importBundles/>
                             <importFeatures>
@@ -100,59 +100,53 @@
                                     caramel:${caramel.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.associations.dependencies:${carbon.platform.version}
+                                    org.wso2.carbon.registry.associations.dependencies:${carbon.registry.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.community.features:${patch.version.421}
+                                    org.wso2.carbon.registry.community.features:${carbon.registry.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.extensions:${carbon.platform.version}
+                                    org.wso2.carbon.registry.core:${carbon.registry.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.core:${patch.version.421}
+                                    org.wso2.carbon.registry.resource.properties:${carbon.registry.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.ui.menu:${carbon.platform.version}
+                                    org.wso2.carbon.registry.ui.menu.governance:${carbon.registry.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.resource.properties:${patch.version.421}
+                                    org.wso2.carbon.registry.contentsearch.server:${carbon.registry.version}
                                 </importFeatureDef>
-                                <importFeatureDef>
-                                    org.wso2.carbon.registry.ui.menu.governance:${carbon.platform.version}
-                                </importFeatureDef>
-                                <importFeatureDef>
-                                    org.wso2.carbon.registry.contentsearch.server:${patch.version.421}
-                                </importFeatureDef>
-                                <importFeatureDef>
-                                    org.wso2.carbon.jaxws.webapp.mgt:${carbon.platform.version}
-                                </importFeatureDef>
+                                <!--<importFeatureDef> C 4.4.0 -->
+                                    <!--org.wso2.carbon.jaxws.webapp.mgt:${carbon.platform.version}-->
+                                <!--</importFeatureDef>-->
                                 <!-- SSO -->
                                 <importFeatureDef>
-                                    org.wso2.carbon.security.mgt:${patch.version.421}
+                                    org.wso2.carbon.security.mgt:${carbon.identity.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.application.authenticator.basicauth.server:${carbon.platform.version}
+                                    org.wso2.carbon.identity.application.authenticator.basicauth.server:${carbon.identity.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.application.authentication.framework.server:${patch.version.421}
+                                    org.wso2.carbon.identity.application.authentication.framework.server:${carbon.identity.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.authenticator.saml2.sso:${patch.version.421}
+                                    org.wso2.carbon.identity.authenticator.saml2.sso:${carbon.identity.version}
                                 </importFeatureDef>
                                 <feaureArtifactDef>
-                                    org.wso2.carbon.identity.sso.saml:${patch.version.421}
+                                    org.wso2.carbon.identity.sso.saml:${carbon.identity.version}
                                 </feaureArtifactDef>
+                                <!--<feaureArtifactDef>-->
+                                    <!--org.wso2.stratos.identity.saml2.sso.mgt:${stratos.version}-->
+                                <!--</feaureArtifactDef>-->
                                 <feaureArtifactDef>
-                                    org.wso2.stratos.identity.saml2.sso.mgt:${stratos.version}
-                                </feaureArtifactDef>
-                                <feaureArtifactDef>
-                                    org.wso2.carbon.identity.core:${patch.version.421}
+                                    org.wso2.carbon.identity.core:${carbon.identity.version}
                                 </feaureArtifactDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.governance.metadata:${patch.version.421}
+                                    org.wso2.carbon.governance.metadata:${carbon.governance.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.governance.lifecycle.management:${carbon.platform.version}
+                                    org.wso2.carbon.governance.lifecycle.management:${carbon.governance.version}
                                 </importFeatureDef>
                                 <!--<importFeatureDef>
                                     org.wso2.carbon.cassandra.explorer:${carbon.platform.version}
@@ -176,23 +170,23 @@
                                     org.wso2.carbon.databridge.cassandra:${carbon.platform.version}
                                 </importFeatureDef>-->
                                 <importFeatureDef>
-                                    org.wso2.carbon.module.mgt.server:${carbon.platform.version}
+                                    org.wso2.carbon.module.mgt.server:${carbon.kernal.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.user.mgt:${patch.version.421}
+                                    org.wso2.carbon.user.mgt:${carbon.commons.version}
                                 </importFeatureDef>
                                 <!--<importFeatureDef>
                                     org.wso2.carbon.databridge.streamdefn.cassandra:${carbon.platform.version}
                                 </importFeatureDef>-->
                                 <!-- Stratos features    -->
-                                <importFeatureDef>
-                                    org.wso2.carbon.stratos.common:2.3.0
-                                </importFeatureDef>
+                                <!--<importFeatureDef> C 4.4.0 -->
+                                    <!--org.wso2.carbon.stratos.common:2.3.0-->
+                                <!--</importFeatureDef>-->
                                 <importFeatureDef>
                                     org.wso2.carbon.event:${patch.version.421}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.ws:${carbon.platform.version}
+                                    org.wso2.carbon.registry.ws:${carbon.registry.version}
                                 </importFeatureDef>
                             </importFeatures>
                         </configuration>

--- a/modules/features/org.wso2.store.styles.feature/pom.xml
+++ b/modules/features/org.wso2.store.styles.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-features</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/org.wso2.store.styles.feature/pom.xml
+++ b/modules/features/org.wso2.store.styles.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-features</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,14 +22,13 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.store</groupId>
     <artifactId>wso2store-features</artifactId>
-    <version>1.1.1</version>
     <packaging>pom</packaging>
     <name>WSO2 Enterprise Store Features</name>
     <url>http://wso2.org</url>

--- a/modules/features/pom.xml
+++ b/modules/features/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.store</groupId>
     <artifactId>wso2store-features</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
     <name>WSO2 Enterprise Store Features</name>
     <url>http://wso2.org</url>

--- a/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
@@ -5,7 +5,7 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.1</version>
+       <version>1.2.1-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -62,7 +62,7 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                                <bundleDef>org.wso2.carbon:org.wso2.carbon.social.core:1.2.0</bundleDef>
+                                <bundleDef>org.wso2.carbon:org.wso2.carbon.social.core:${carbon.social.version}</bundleDef>
                             </bundles>
 
                             <importFeatures>

--- a/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
@@ -5,14 +5,13 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.0</version>
+       <version>1.2.1</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.core.feature</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0</version>
     <name>WSO2 Carbon - Social - Core Feature</name>
 
 
@@ -67,7 +66,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.platform.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
                                 <!--importFeatureDef>org.wso2.carbon.bam.toolbox.deployer:4.2.1</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.event.stream.manager:1.0.1</importFeatureDef-->
                             </importFeatures>

--- a/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
@@ -3,14 +3,13 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.0</version>
+       <version>1.2.1</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.db.adapter.feature</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0</version>
     <name>WSO2 Carbon - Social - Adapter Feature</name>
     <build>
         <plugins>
@@ -63,7 +62,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.platform.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
                             </importFeatures>
 
                         </configuration>

--- a/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
@@ -3,7 +3,7 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.1</version>
+       <version>1.2.1-SNAPSHOT</version>
        <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/social/org.wso2.carbon.social.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.feature/pom.xml
@@ -5,7 +5,7 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.1</version>
+       <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/social/org.wso2.carbon.social.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.feature/pom.xml
@@ -5,14 +5,13 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.0</version>
+       <version>1.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.feature</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0</version>
     <name>WSO2 Carbon - Social - Feature</name>
 
 
@@ -34,12 +33,12 @@
                             <id>org.wso2.carbon.social</id>
                             <propertiesFile>../../../etc/feature.properties</propertiesFile>
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:4.2.0</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
                             </importFeatures>
                             <includedFeatures>
-                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.core.feature:1.2.0</includedFeatureDef>
-                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.sql.feature:1.2.0</includedFeatureDef>
-                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.db.adapter.feature:1.2.0</includedFeatureDef>
+                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.core.feature:${project.version}</includedFeatureDef>
+                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.sql.feature:${project.version}</includedFeatureDef>
+                                <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.db.adapter.feature:${project.version}</includedFeatureDef>
                             </includedFeatures>
                         </configuration>
                     </execution>

--- a/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
@@ -5,7 +5,7 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.1</version>
+       <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
@@ -5,14 +5,13 @@
    <parent>
        <groupId>org.wso2.carbon</groupId>
        <artifactId>social-feature</artifactId>
-       <version>1.2.0</version>
+       <version>1.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.social.sql.feature</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.0</version>
     <name>WSO2 Carbon - Social - SQL Feature</name>
 
 
@@ -82,7 +81,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.platform.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
                                 <!--importFeatureDef>org.wso2.carbon.bam.toolbox.deployer:4.2.1</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.event.stream.manager:1.0.1</importFeatureDef-->
                             </importFeatures>

--- a/modules/features/social/pom.xml
+++ b/modules/features/social/pom.xml
@@ -21,13 +21,13 @@
      <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.wso2.carbon</groupId>
     <artifactId>social-feature</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Social Feature Aggregator Module</name>

--- a/modules/features/social/pom.xml
+++ b/modules/features/social/pom.xml
@@ -21,13 +21,13 @@
      <parent>
         <groupId>org.wso2.store</groupId>
         <artifactId>wso2store-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.wso2.carbon</groupId>
     <artifactId>social-feature</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.1-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Social Feature Aggregator Module</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.store</groupId>
     <artifactId>wso2store-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 	<name>WSO2 Enterprise Store - Parent</name>
     <url>http://wso2.org/projects/appserver/java</url>
@@ -90,7 +90,9 @@
         <carbon.commons.version>4.4.2</carbon.commons.version>
         <carbon.registry.version>4.4.3</carbon.registry.version>
         <carbon.governance.version>4.5.1</carbon.governance.version>
-        <carbon.store.bundle.version>1.1.1</carbon.store.bundle.version>
+        <carbon.social.version>1.2.1-SNAPSHOT</carbon.social.version>
+        <carbon.social.pkg.version>1.2.1</carbon.social.pkg.version>
+        <carbon.store.bundle.version>1.1.1-SNAPSHOT</carbon.store.bundle.version>
 
         <!-- jaggery versions -->
         <jaggery.feature.version>0.10.1</jaggery.feature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.store</groupId>
     <artifactId>wso2store-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 	<name>WSO2 Enterprise Store - Parent</name>
     <url>http://wso2.org/projects/appserver/java</url>
@@ -84,15 +84,20 @@
 
     <properties>
         <ues.version>1.0.0</ues.version>
-        <carbon.kernal.version>4.2.0</carbon.kernal.version>
-        <carbon.platform.version>4.2.0</carbon.platform.version>
+        <carbon.kernal.version>4.4.0</carbon.kernal.version>
+        <carbon.platform.version>4.4.0</carbon.platform.version>
+        <carbon.identity.version>4.5.0</carbon.identity.version>
+        <carbon.commons.version>4.4.2</carbon.commons.version>
+        <carbon.registry.version>4.4.3</carbon.registry.version>
+        <carbon.governance.version>4.5.1</carbon.governance.version>
+        <carbon.store.bundle.version>1.1.1</carbon.store.bundle.version>
 
         <!-- jaggery versions -->
-        <jaggery.feature.version>0.9.0.ALPHA4.wso2v4</jaggery.feature.version>
+        <jaggery.feature.version>0.10.1</jaggery.feature.version>
 
         <!-- patch versions -->
-        <patch.version.421>4.2.1</patch.version.421>
-        <patch.version.422>4.2.2</patch.version.422>
+        <patch.version.421>4.4.0</patch.version.421>
+        <patch.version.422>4.4.0</patch.version.422>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 		<stratos.version>2.2.0</stratos.version>
 		<stratos.patch.version.221>2.2.1</stratos.patch.version.221>
@@ -120,11 +125,12 @@
 		<wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
 		<sso.hostobjects.version>1.0.1</sso.hostobjects.version>
 
-        <rhino.osgi.version>1.7.0.R4.wso2v1-SNAPSHOT</rhino.osgi.version>
+        <rhino.osgi.version>1.7.0.R4.wso2v1</rhino.osgi.version>
         <commons-codec.osgi.version>1.4.0.wso2v1</commons-codec.osgi.version>
         <opensaml2.wso2.version>2.4.1.wso2v1</opensaml2.wso2.version>
         <commons-logging.version>1.1.1</commons-logging.version>
         <cep.component.version>1.0.0</cep.component.version>
+        <google.gson.version>2.1</google.gson.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
This contains Carbon 4.4.0 upgrade for App Manager branch.
Store versions changed to 1.1.1-SNAPSHOT
Social versions changed to 1.2.1-SNAPSHOT