### PR TITLE
App manager 1.1 Carbon 4.4.1 Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
 
     <properties>
         <ues.version>1.0.0</ues.version>
-        <carbon.kernal.version>4.4.0</carbon.kernal.version>
-        <carbon.platform.version>4.4.0</carbon.platform.version>
-        <carbon.identity.version>4.5.0</carbon.identity.version>
+        <carbon.kernal.version>4.4.1</carbon.kernal.version>
+        <carbon.platform.version>4.4.1</carbon.platform.version>
+        <carbon.identity.version>4.5.1</carbon.identity.version>
         <carbon.commons.version>4.4.2</carbon.commons.version>
         <carbon.registry.version>4.4.3</carbon.registry.version>
         <carbon.governance.version>4.5.1</carbon.governance.version>
@@ -98,8 +98,8 @@
         <jaggery.feature.version>0.10.1</jaggery.feature.version>
 
         <!-- patch versions -->
-        <patch.version.421>4.4.0</patch.version.421>
-        <patch.version.422>4.4.0</patch.version.422>
+        <patch.version.421>4.4.1</patch.version.421>
+        <patch.version.422>4.4.1</patch.version.422>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 		<stratos.version>2.2.0</stratos.version>
 		<stratos.patch.version.221>2.2.1</stratos.patch.version.221>


### PR DESCRIPTION
Version upgrade to carbon 4.4.1. AppM v1.1.0 with C 4.4.0 is not released. Hence this version upgrade is safe.