### PR TITLE
Changing the upstream component versions to have "compatible" qualifier.

### DIFF
--- a/modules/features/org.wso2.store.feature/pom.xml
+++ b/modules/features/org.wso2.store.feature/pom.xml
@@ -95,59 +95,59 @@
                                     org.jaggeryjs:${jaggery.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.webapp.mgt.server:${patch.version.421}
+                                    org.wso2.carbon.webapp.mgt.server:compatible:${carbon.kernal.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
                                     caramel:${caramel.feature.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.associations.dependencies:${carbon.registry.version}
+                                    org.wso2.carbon.registry.associations.dependencies:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.community.features:${carbon.registry.version}
+                                    org.wso2.carbon.registry.community.features:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.core:${carbon.registry.version}
+                                    org.wso2.carbon.registry.core:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.resource.properties:${carbon.registry.version}
+                                    org.wso2.carbon.registry.resource.properties:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.ui.menu.governance:${carbon.registry.version}
+                                    org.wso2.carbon.registry.ui.menu.governance:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.contentsearch.server:${carbon.registry.version}
+                                    org.wso2.carbon.registry.contentsearch.server:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                                 <!--<importFeatureDef> C 4.4.0 -->
                                     <!--org.wso2.carbon.jaxws.webapp.mgt:${carbon.platform.version}-->
                                 <!--</importFeatureDef>-->
                                 <!-- SSO -->
                                 <importFeatureDef>
-                                    org.wso2.carbon.security.mgt:${carbon.identity.version}
+                                    org.wso2.carbon.security.mgt:compatible:${carbon.identity.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.application.authenticator.basicauth.server:${carbon.identity.version}
+                                    org.wso2.carbon.identity.application.authenticator.basicauth.server:compatible:${carbon.identity.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.application.authentication.framework.server:${carbon.identity.version}
+                                    org.wso2.carbon.identity.application.authentication.framework.server:compatible:${carbon.identity.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.identity.authenticator.saml2.sso:${carbon.identity.version}
+                                    org.wso2.carbon.identity.authenticator.saml2.sso:compatible:${carbon.identity.base.version}
                                 </importFeatureDef>
                                 <feaureArtifactDef>
-                                    org.wso2.carbon.identity.sso.saml:${carbon.identity.version}
+                                    org.wso2.carbon.identity.sso.saml:compatible:${carbon.identity.base.version}
                                 </feaureArtifactDef>
                                 <!--<feaureArtifactDef>-->
                                     <!--org.wso2.stratos.identity.saml2.sso.mgt:${stratos.version}-->
                                 <!--</feaureArtifactDef>-->
                                 <feaureArtifactDef>
-                                    org.wso2.carbon.identity.core:${carbon.identity.version}
+                                    org.wso2.carbon.identity.core:compatible:${carbon.identity.base.version}
                                 </feaureArtifactDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.governance.metadata:${carbon.governance.version}
+                                    org.wso2.carbon.governance.metadata:compatible:${carbon.governance.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.governance.lifecycle.management:${carbon.governance.version}
+                                    org.wso2.carbon.governance.lifecycle.management:compatible:${carbon.governance.base.version}
                                 </importFeatureDef>
                                 <!--<importFeatureDef>
                                     org.wso2.carbon.cassandra.explorer:${carbon.platform.version}
@@ -156,7 +156,7 @@
                                     org.wso2.carbon.cassandra:${carbon.platform.version}
                                 </importFeatureDef>-->
                                 <importFeatureDef>
-                                    org.wso2.carbon.cassandra-jdbc-1.1.1.server:4.0.1
+                                    org.wso2.carbon.cassandra-jdbc-1.1.1.server:optional:4.0.1
                                 </importFeatureDef>
                                <!-- <importFeatureDef>
                                     org.wso2.carbon.databridge.datapublisher:4.2.1
@@ -171,10 +171,10 @@
                                     org.wso2.carbon.databridge.cassandra:${carbon.platform.version}
                                 </importFeatureDef>-->
                                 <importFeatureDef>
-                                    org.wso2.carbon.module.mgt.server:${carbon.kernal.version}
+                                    org.wso2.carbon.module.mgt.server:compatible:${carbon.kernal.base.version}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.user.mgt:${carbon.identity.version}
+                                    org.wso2.carbon.user.mgt:compatible:${carbon.identity.base.version}
                                 </importFeatureDef>
                                 <!--<importFeatureDef>
                                     org.wso2.carbon.databridge.streamdefn.cassandra:${carbon.platform.version}
@@ -184,10 +184,10 @@
                                     <!--org.wso2.carbon.stratos.common:2.3.0-->
                                 <!--</importFeatureDef>-->
                                 <importFeatureDef>
-                                    org.wso2.carbon.event:${patch.version.421}
+                                    org.wso2.carbon.event:compatible:${patch.version.421}
                                 </importFeatureDef>
                                 <importFeatureDef>
-                                    org.wso2.carbon.registry.ws:${carbon.registry.version}
+                                    org.wso2.carbon.registry.ws:compatible:${carbon.registry.base.version}
                                 </importFeatureDef>
                             </importFeatures>
                         </configuration>

--- a/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.core.feature/pom.xml
@@ -66,7 +66,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:compatible:${carbon.kernal.base.version}</importFeatureDef>
                                 <!--importFeatureDef>org.wso2.carbon.bam.toolbox.deployer:4.2.1</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.event.stream.manager:1.0.1</importFeatureDef-->
                             </importFeatures>

--- a/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.db.adapter.feature/pom.xml
@@ -62,7 +62,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:compatible:${carbon.kernal.base.version}</importFeatureDef>
                             </importFeatures>
 
                         </configuration>

--- a/modules/features/social/org.wso2.carbon.social.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.feature/pom.xml
@@ -33,7 +33,7 @@
                             <id>org.wso2.carbon.social</id>
                             <propertiesFile>../../../etc/feature.properties</propertiesFile>
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:compatible:${carbon.kernal.base.version}</importFeatureDef>
                             </importFeatures>
                             <includedFeatures>
                                 <includedFeatureDef>org.wso2.carbon:org.wso2.carbon.social.core.feature:${project.version}</includedFeatureDef>

--- a/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
+++ b/modules/features/social/org.wso2.carbon.social.sql.feature/pom.xml
@@ -81,7 +81,7 @@
                             </bundles>
 
                             <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernal.version}</importFeatureDef>
+                                <importFeatureDef>org.wso2.carbon.core.server:compatible:${carbon.kernal.base.version}</importFeatureDef>
                                 <!--importFeatureDef>org.wso2.carbon.bam.toolbox.deployer:4.2.1</importFeatureDef>
                                 <importFeatureDef>org.wso2.carbon.event.stream.manager:1.0.1</importFeatureDef-->
                             </importFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,15 @@
     <properties>
         <ues.version>1.0.0</ues.version>
         <carbon.kernal.version>4.4.1</carbon.kernal.version>
+        <carbon.kernal.base.version>4.4.0</carbon.kernal.base.version>
         <carbon.platform.version>4.4.1</carbon.platform.version>
         <carbon.identity.version>4.5.4</carbon.identity.version>
+        <carbon.identity.base.version>4.4.0</carbon.identity.base.version>
         <carbon.commons.version>4.4.2</carbon.commons.version>
         <carbon.registry.version>4.4.3</carbon.registry.version>
+        <carbon.registry.base.version>4.4.0</carbon.registry.base.version>
         <carbon.governance.version>4.5.1</carbon.governance.version>
+        <carbon.governance.base.version>4.4.0</carbon.governance.base.version>
         <carbon.social.version>1.2.1-SNAPSHOT</carbon.social.version>
         <carbon.social.pkg.version>1.2.1</carbon.social.pkg.version>
         <carbon.store.bundle.version>1.1.1-SNAPSHOT</carbon.store.bundle.version>
@@ -123,7 +127,7 @@
         <maven-project-info-report-plugin.version>2.4</maven-project-info-report-plugin.version>
         <maven-buildnumber-plugin.version>1.1</maven-buildnumber-plugin.version>
         <maven-dependency-plugin.version>2.4</maven-dependency-plugin.version>
-        <caramel.feature.version>1.0.0</caramel.feature.version>
+        <caramel.feature.version>1.0.1</caramel.feature.version>
 		<wso2.slf4j.version>1.5.10.wso2v1</wso2.slf4j.version>
 		<sso.hostobjects.version>1.0.1</sso.hostobjects.version>
 


### PR DESCRIPTION
This will allow dependent components to bundle with carbon 4.4.0, 4.4.1, 4.4.2, etc.