### PR TITLE
Fix for STORE-1318: Comment out unused provisioning connector configs

### DIFF
--- a/modules/distribution/src/repository/conf/identity/identity-providers/default.xml
+++ b/modules/distribution/src/repository/conf/identity/identity-providers/default.xml
@@ -11,12 +11,12 @@
 	<DefaultAuthenticatorConfig>
 	</DefaultAuthenticatorConfig>
 	<ProvisioningConnectorConfigs>
-		<ProvisioningConnectorConfig>
+		<!--ProvisioningConnectorConfig>
 			<ProvisioningProperties>
 			</ProvisioningProperties>
-		</ProvisioningConnectorConfig>
+		</ProvisioningConnectorConfig-->
 	</ProvisioningConnectorConfigs>
-	<DefaultProvisioningConnectorConfig></DefaultProvisioningConnectorConfig>
+	<!--DefaultProvisioningConnectorConfig></DefaultProvisioningConnectorConfig-->
 	<ClaimConfig></ClaimConfig>
 	<Certificate></Certificate>
 	<PermissionAndRoleConfig></PermissionAndRoleConfig>


### PR DESCRIPTION
In this PR:

* Comment out unused provisioning connector configs

Addresses the following issue: [STORE-1318](https://wso2.org/jira/browse/STORE-1318)