### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expressions should be removed

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ESIntegrationTest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ESIntegrationTest.java
@@ -140,7 +140,7 @@ public abstract class ESIntegrationTest {
     private void validateServiceUrl(String serviceUrl, Tenant tenant) {
         //if user mode is null can not validate the service url
         if (userMode != null) {
-            if ((userMode == TestUserMode.TENANT_ADMIN || userMode == TestUserMode.TENANT_USER)) {
+            if (userMode == TestUserMode.TENANT_ADMIN || userMode == TestUserMode.TENANT_USER) {
                 Assert.assertTrue(serviceUrl.contains("/t/" + tenant.getDomain() + "/"), "invalid service url for tenant. " + serviceUrl);
             } else {
                 Assert.assertFalse(serviceUrl.contains("/t/"), "Invalid service url for user. " + serviceUrl);

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/lifecycle/LifecycleUtil.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/lifecycle/LifecycleUtil.java
@@ -216,7 +216,7 @@ public class LifecycleUtil {
         WorkItem[] workItems = WorkItemClient.getWorkItems(humanTaskAdminClient);
         for (WorkItem workItem : workItems) {
             // search for the correct notification
-            if ((workItem.getPresentationSubject().toString()).contains(type)) {
+            if (workItem.getPresentationSubject().toString().contains(type)) {
                 success = true;
                 break;
             }

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/JMXClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/JMXClient.java
@@ -155,7 +155,7 @@ public class JMXClient implements NotificationListener {
         Calendar startTime = Calendar.getInstance();
         try {
             while (!isSuccess()) {
-                if (((Calendar.getInstance().getTimeInMillis() - startTime.getTimeInMillis())) < 60000) {
+                if (Calendar.getInstance().getTimeInMillis() - startTime.getTimeInMillis() < 60000) {
                     Thread.sleep(1000);
                 } else {
                     break;

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/ManagementConsoleSubscription.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/ManagementConsoleSubscription.java
@@ -151,7 +151,7 @@ public class ManagementConsoleSubscription {
         WorkItem[] workItems = WorkItemClient.getWorkItems(humanTaskAdminClient);
 
         for (WorkItem workItem : workItems) {
-            if ((workItem.getPresentationSubject().toString()).contains(path + " was updated.")) {
+            if (workItem.getPresentationSubject().toString().contains(path + " was updated.")) {
                 success = true;
                 break;
             }

--- a/modules/integration/tests-common/ui-pages/src/main/java/org/wso2/es/integration/common/ui/page/LoginPage.java
+++ b/modules/integration/tests-common/ui-pages/src/main/java/org/wso2/es/integration/common/ui/page/LoginPage.java
@@ -40,7 +40,7 @@ public class LoginPage {
         this.driver = driver;
 
         // Check that we're on the right page.
-        if (!(driver.getCurrentUrl().contains("login.jsp"))) {
+        if (!driver.getCurrentUrl().contains("login.jsp")) {
             // Alternatively, we could navigate to the login page, perhaps logging out first
             throw new IllegalStateException("This is not the login page");
         }
@@ -51,7 +51,7 @@ public class LoginPage {
         this.isCloudEnvironment = isCloudEnvironment;
         // Check that we're on the right page.
         if (this.isCloudEnvironment) {
-            if (!(driver.getCurrentUrl().contains("home/index.html"))) {
+            if (!driver.getCurrentUrl().contains("home/index.html")) {
                 // Alternatively, we could navigate to the login page, perhaps logging out first
                 throw new IllegalStateException("This is not the cloud login page");
             }

--- a/modules/integration/tests-common/ui-pages/src/main/java/org/wso2/es/integration/common/ui/page/main/HomePage.java
+++ b/modules/integration/tests-common/ui-pages/src/main/java/org/wso2/es/integration/common/ui/page/main/HomePage.java
@@ -71,7 +71,7 @@ public class HomePage {
     public HomePage(boolean isTenant, WebDriver driver) throws IOException {
         this.isTenant = isTenant;
         if (this.isTenant) {
-            if (!(driver.getCurrentUrl().contains("loginStatus=true"))) {
+            if (!driver.getCurrentUrl().contains("loginStatus=true")) {
                 throw new IllegalStateException("This is not the home page");
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
