### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/AuthenticateStub.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/AuthenticateStub.java
@@ -29,6 +29,9 @@ import org.wso2.carbon.utils.CarbonUtils;
 public class AuthenticateStub {
     private static final Log log = LogFactory.getLog(AuthenticateStub.class);
 
+    private AuthenticateStub() {
+    }
+
     /**
      * Stub authentication method
      *

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ManifestUtils.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ManifestUtils.java
@@ -36,6 +36,9 @@ public class ManifestUtils {
 
     private static final Log log = LogFactory.getLog(ManifestUtils.class);
 
+    private ManifestUtils() {
+    }
+
     /**
      * Reads the manifest file and then converts the JSON content to an instance of the InstallationManifest
      * DAO

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/ManagementConsoleSubscription.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/ManagementConsoleSubscription.java
@@ -37,6 +37,9 @@ public class ManagementConsoleSubscription {
     private static String userName;
     private static String userNameWithoutDomain;
 
+    private ManagementConsoleSubscription() {
+    }
+
     /**
      * Subscribe for management console notifications and receive the
      * notification

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/WorkItemClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/WorkItemClient.java
@@ -33,6 +33,9 @@ import java.util.Date;
 public class WorkItemClient {
     private static Log log = LogFactory.getLog(WorkItemClient.class);
 
+    private WorkItemClient() {
+    }
+
     /**
      * get the existing management console notifications
      *

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/FileUploadWithAttachmentUtil.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/FileUploadWithAttachmentUtil.java
@@ -31,6 +31,9 @@ import java.io.IOException;
 
 public class FileUploadWithAttachmentUtil {
 
+    private FileUploadWithAttachmentUtil() {
+    }
+
     /**
      * This method uploads a content-type asset (ex: wsdl,policy,wadl,swagger)
      * to a running G-Reg instance

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/GovernanceRestApiUtil.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/GovernanceRestApiUtil.java
@@ -31,6 +31,9 @@ import javax.ws.rs.core.MediaType;
  */
 public class GovernanceRestApiUtil {
 
+    private GovernanceRestApiUtil() {
+    }
+
     /**
      * @param genericRestClient generic rest client instance
      * @param dataBody          data body for REST request

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/version/test/utils/VersionUtils.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/version/test/utils/VersionUtils.java
@@ -29,6 +29,9 @@ import java.rmi.RemoteException;
 public class VersionUtils {
     private static final Log log = LogFactory.getLog(VersionUtils.class);
 
+    private VersionUtils() {
+    }
+
     public static VersionPath[] deleteAllVersions(ResourceAdminServiceClient resourceAdminClient,
                                                   String path)
             throws ResourceAdminServiceExceptionException, RemoteException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
