### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ManifestUtils.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ManifestUtils.java
@@ -54,7 +54,8 @@ public class ManifestUtils {
             log.error("Unable to read the installation manifest file at " + manifestPath, e);
             throw new IOException("Unable to read the installation manifest file.");
         } finally {
-            reader.close();
+            if (reader != null)
+                reader.close();
         }
         return manifest;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
