### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/HumanTaskAdminClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/HumanTaskAdminClient.java
@@ -78,7 +78,7 @@ public class HumanTaskAdminClient {
 		if (resultSet == null || resultSet.getRow() == null || resultSet.getRow().length == 0) {
 			return new WorkItem[0];
 		}
-		List<WorkItem> workItems = new LinkedList<WorkItem>();
+		List<WorkItem> workItems = new LinkedList<>();
 		for (TTaskSimpleQueryResultRow row : resultSet.getRow()) {
 			URI id = row.getId();
 			String taskUser = "";

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/UserManagementClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/es/integration/common/clients/UserManagementClient.java
@@ -125,7 +125,7 @@ public class UserManagementClient {
 
     public void updateUserListOfRole(String roleName, String[] addingUsers,
                                      String[] deletingUsers) throws Exception {
-        List<FlaggedName> updatedUserList = new ArrayList<FlaggedName>();
+        List<FlaggedName> updatedUserList = new ArrayList<>();
         if (addingUsers != null) {
             for (String addUser : addingUsers) {
                 FlaggedName fName = new FlaggedName();

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ESServerManager.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/ESServerManager.java
@@ -34,7 +34,7 @@ public class ESServerManager {
     private CarbonServerManager carbonServer;
     private String carbonZip;
     private int portOffset;
-    private Map<String, String> commandMap = new HashMap<String, String>();
+    private Map<String, String> commandMap = new HashMap<>();
     private static final Log log = LogFactory.getLog(TestServerManager.class);
     private String carbonHome;
 

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/GenericRestClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/GenericRestClient.java
@@ -58,8 +58,8 @@ public class GenericRestClient {
 
     public static void main(String[] args) throws JSONException {
         GenericRestClient genericRestClient = new GenericRestClient();
-        Map<String, String> queryParamMap = new HashMap<String, String>();
-        Map<String, String> headerMap = new HashMap<String, String>();
+        Map<String, String> queryParamMap = new HashMap<>();
+        Map<String, String> headerMap = new HashMap<>();
         genericRestClient.setKeysForRestClient();
         JSONObject obj = new JSONObject(genericRestClient.
                 geneticRestRequestPost("https://localhost:9443/publisher/apis/authenticate/",

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/domain/InstallationManifest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/domain/InstallationManifest.java
@@ -32,7 +32,7 @@ public class InstallationManifest {
     private Map<String,ResourcePackage> packages;
 
     public InstallationManifest() {
-        this.packages = new HashMap<String, ResourcePackage>(); //new ArrayList<ResourcePackage>();
+        this.packages = new HashMap<>(); //new ArrayList<ResourcePackage>();
     }
 
     /**

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/JMXClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/es/integration/common/utils/subscription/JMXClient.java
@@ -60,7 +60,7 @@ public class JMXClient implements NotificationListener {
                                       RMIServerPort + "/jndi/rmi://" +
                                       NetworkUtils.getLocalHostname() + ":" +
                                       RMIRegistryPort + "/jmxrmi");
-            Hashtable<String, String[]> hashT = new Hashtable<String, String[]>();
+            Hashtable<String, String[]> hashT = new Hashtable<>();
             String[] credentials = new String[]{userName, password};
             hashT.put("jmx.remote.credentials", credentials);
             jmxc = JMXConnectorFactory.connect(url, hashT);
@@ -90,7 +90,7 @@ public class JMXClient implements NotificationListener {
                                       RMIServerPort + "/jndi/rmi://" +
                                       NetworkUtils.getLocalHostname() + ":" +
                                       RMIRegistryPort + "/jmxrmi");
-            Hashtable<String, String[]> hashT = new Hashtable<String, String[]>();
+            Hashtable<String, String[]> hashT = new Hashtable<>();
             String[] credentials = new String[]{userName, password};
             hashT.put("jmx.remote.credentials", credentials);
             jmxc = JMXConnectorFactory.connect(url, hashT);

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/publisher/generic/RestResourcePublisherESTestCase.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/publisher/generic/RestResourcePublisherESTestCase.java
@@ -64,8 +64,8 @@ public class RestResourcePublisherESTestCase extends ESTestBaseTest {
     public void init() throws Exception {
         super.init(userMode);
         genericRestClient = new GenericRestClient();
-        queryParamMap = new HashMap<String, String>();
-        headerMap = new HashMap<String, String>();
+        queryParamMap = new HashMap<>();
+        headerMap = new HashMap<>();
         resourcePath = FrameworkPathUtil.getSystemResourceLocation()
                        + "artifacts" + File.separator + "GREG" + File.separator;
         publisherUrl = publisherContext.getContextUrls()

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/ESTestBaseTest.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/ESTestBaseTest.java
@@ -40,8 +40,8 @@ public class ESTestBaseTest extends ESIntegrationTest {
     Map<String, String> headerMap;
 
     public ESTestBaseTest() {
-        queryParamMap = new HashMap<String, String>();
-        headerMap = new HashMap<String, String>();
+        queryParamMap = new HashMap<>();
+        headerMap = new HashMap<>();
     }
 
     /**
@@ -134,7 +134,7 @@ public class ESTestBaseTest extends ESIntegrationTest {
                                    String publisherUrl,
                                    String cookieHeader,
                                    GenericRestClient genericRestClient) throws JSONException {
-        Map<String, String> assetTypeParamMap = new HashMap<String, String>();
+        Map<String, String> assetTypeParamMap = new HashMap<>();
         assetTypeParamMap.put("type", assetType);
         return genericRestClient.geneticRestRequestGet
                 (publisherUrl + "/assets/" + assetId
@@ -145,7 +145,7 @@ public class ESTestBaseTest extends ESIntegrationTest {
                                         String publisherUrl,
                                         String cookieHeader,
                                         GenericRestClient genericRestClient) throws JSONException {
-        Map<String, String> assetTypeParamMap = new HashMap<String, String>();
+        Map<String, String> assetTypeParamMap = new HashMap<>();
         assetTypeParamMap.put("type", assetType);
         ClientResponse response =
                 genericRestClient.geneticRestRequestGet
@@ -375,7 +375,7 @@ public class ESTestBaseTest extends ESIntegrationTest {
                                                                                 queryParamMap, "text/html", headerMap, cookieHeader);
         String response = clientResponse.getEntity(String.class);
         String[] dataArray = response.split("data-uuid=");
-        Map<String, String> assocMap = new HashMap<String, String>();
+        Map<String, String> assocMap = new HashMap<>();
         for (int i = 1; i < dataArray.length; i++) {
             String mediaType = null;
             if (dataArray[i].contains("resource-type")) {

--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/ESTestCommonUtils.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/carbon/registry/es/utils/ESTestCommonUtils.java
@@ -118,7 +118,7 @@ public class ESTestCommonUtils {
                 queryParamMap, "text/html", headerMap, cookieHeader);
         String response = clientResponse.getEntity(String.class);
         String[] dataArray = response.split("data-uuid=");
-        Map<String, String> assocMap = new HashMap<String, String>();
+        Map<String, String> assocMap = new HashMap<>();
         for (int i = 1; i < dataArray.length; i++) {
             String mediaType = null;
             if (dataArray[i].contains("application")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
